### PR TITLE
[t139574][FIX] onchange resets values

### DIFF
--- a/syndicom_main/models/helpdesk_ticket.py
+++ b/syndicom_main/models/helpdesk_ticket.py
@@ -9,22 +9,21 @@ class HelpdeskTicket(models.Model):
 
     @api.onchange('address_search_id')
     def _onchange_partner_adress(self):
-        for rec in self:
+        if self.address_search_id:
 
-            if rec.address_search_id.city_id:
-                rec.city_id = rec.address_search_id.city_id
+            if self.address_search_id.city_id:
+                self.city_id = self.address_search_id.city_id
             
-            if rec.address_search_id.country_id:
-                rec.country_id = rec.address_search_id.country_id
+            if self.address_search_id.country_id:
+                self.country_id = self.address_search_id.country_id
 
-            if rec.address_search_id.state_id:
-                rec.state_id = rec.address_search_id.state_id
+            if self.address_search_id.state_id:
+                self.state_id = self.address_search_id.state_id
             
-            rec.street = rec.address_search_id.street
-            rec.zip = rec.address_search_id.zip
-            rec.city = rec.address_search_id.city
+            self.street = self.address_search_id.street
+            self.zip = self.address_search_id.zip
+            self.city = self.address_search_id.city
 
-            rec.address_search_id = False
+            self.address_search_id = False
 
 
-    

--- a/syndicom_main/models/res_partner.py
+++ b/syndicom_main/models/res_partner.py
@@ -31,22 +31,22 @@ class ResPartner(models.Model):
     
     @api.onchange('address_search_id')
     def _onchange_partner_adress(self):
-        for rec in self:
+        if self.address_search_id:
 
-            if rec.address_search_id.city_id:
-                rec.city_id = rec.address_search_id.city_id
+            if self.address_search_id.city_id:
+                self.city_id = self.address_search_id.city_id
             
-            if rec.address_search_id.country_id:
-                rec.country_id = rec.address_search_id.country_id
+            if self.address_search_id.country_id:
+                self.country_id = self.address_search_id.country_id
 
-            if rec.address_search_id.state_id:
-                rec.state_id = rec.address_search_id.state_id
+            if self.address_search_id.state_id:
+                self.state_id = self.address_search_id.state_id
             
-            rec.street = rec.address_search_id.street
-            rec.zip = rec.address_search_id.zip
-            rec.city = rec.address_search_id.city
+            self.street = self.address_search_id.street
+            self.zip = self.address_search_id.zip
+            self.city = self.address_search_id.city
 
-            rec.address_search_id = False
+            self.address_search_id = False
 
     mobile = fields.Char(tracking=True)   
     phone = fields.Char(tracking=True)
@@ -62,4 +62,3 @@ class ResPartner(models.Model):
 
 
 
-    


### PR DESCRIPTION
- If the `address_search_id` is not set, then the values for the street, zip and city were reset. This was wrong.
- The iteration over `self` has been corrected, since it's not needed on onchanges.