### PR TITLE
FIX order in __init__.py due to init()

### DIFF
--- a/syndicom_vollzug/models/__init__.py
+++ b/syndicom_vollzug/models/__init__.py
@@ -8,8 +8,8 @@ from . import vollzug_declaration_person
 from . import vollzug_declaration_stage
 from . import vollzug_declaration_wizard
 from . import vollzug_declaration_wizard_reminder
-from . import vollzug_declaration_check
 from . import vollzug_notice
 from . import vollzug_notice_place
 from . import vollzug_contact_type
 from . import vollzug_pricelist
+from . import vollzug_declaration_check


### PR DESCRIPTION
When installing the module syndicom_vollzug in an empty database, the file models/vollzug_declaration_check.py

The file models/vollzug_declaration_check.py contains an init() method, that executes when the module is installed. This method calls _query(), that refers to the table syndicom_vollzug_contact_type. This is the table for the model syndicom.vollzug.contact.type, defined in the file models/vollzug_contact_type, that is loaded after in the \_\_init\_\_.py. As a result, when the init() is executed, the table is not yet created, thus an exception for psycopg2.errors.UndefinedTable is raised, blocking the installation.

One solution is to move the file down in the \_\_init\_\_.py.
