### PR TITLE
[t154397] CLA field for relations; dead-code; licence

### DIFF
--- a/syndicom_vollzug/__manifest__.py
+++ b/syndicom_vollzug/__manifest__.py
@@ -5,7 +5,7 @@
     'website': "https://syndicom.ch",
     'category': 'Sales/CRM',
     'version': '15.0.1.0.3',
-    'license': 'LGPL-3',
+    'license': 'AGPL-3',
     'summary': "Vollzug",
     'description': "Modul zum verwalten der GAV-Unterstellungen und entsprechenden Deklarationsaufforderungen",
     'depends': [
@@ -26,6 +26,7 @@
         'views/vollzug_pricelist.xml',
         'views/vollzug_declaration_wizard.xml',
         'views/vollzug_notice.xml',
+        'views/res_partner_relation_type.xml',
         'views/vollzug_cashback.xml',
         'views/vollzug_declaration_wizard_reminder.xml',
         'views/inherited_res_partner_form_view.xml',

--- a/syndicom_vollzug/models/__init__.py
+++ b/syndicom_vollzug/models/__init__.py
@@ -2,6 +2,7 @@
 
 from . import res_config_settings
 from . import res_partner
+from . import res_partner_relation_type
 from . import project_task
 from . import vollzug_declaration
 from . import vollzug_declaration_person

--- a/syndicom_vollzug/models/res_config_settings.py
+++ b/syndicom_vollzug/models/res_config_settings.py
@@ -6,11 +6,6 @@ from odoo import fields, models
 class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
-    syn_declaration_cla_imputed = fields.Many2one(comodel_name='res.partner.relation.type',string='Beziehung für GAV Unterstellung',
-        config_parameter='syndicom_vollzug.cla_imputed',
-        default="", 
-        )
-
     syn_declaration_association_imputed = fields.Many2one(comodel_name='res.partner.relation.type',string='Beziehung für Verbandsmitgliedschaft',
         config_parameter='syndicom_vollzug.association_imputed',
         default="", 

--- a/syndicom_vollzug/models/res_partner_relation_type.py
+++ b/syndicom_vollzug/models/res_partner_relation_type.py
@@ -1,0 +1,17 @@
+##############################################################################
+# Copyright (c) 2024 braintec AG (https://braintec.com)
+# All Rights Reserved
+#
+# Licensed under the AGPL-3.0 (http://www.gnu.org/licenses/agpl.html).
+# See LICENSE file for full licensing details.
+##############################################################################
+from odoo import models, fields
+
+
+class ResPartnerRelationType(models.Model):
+    _inherit = 'res.partner.relation.type'
+
+    cla_imputed_ok = fields.Boolean(
+        'Use for CLA Imputed?',
+        default=False,
+    )

--- a/syndicom_vollzug/models/vollzug_declaration.py
+++ b/syndicom_vollzug/models/vollzug_declaration.py
@@ -221,21 +221,6 @@ class SyndicomvollzugDeclaration(models.Model):
             else:
                 record.overdue = 0
 
-    def _check_cla_start_date(self):
-        for record in self:
-            cla_imputed = self.env['ir.config_parameter'].sudo().get_param('syndicom_vollzug.cla_imputed')
-            cla_imputed = str(cla_imputed) if cla_imputed else '0'
-
-            relation = self.env['res.partner.relation.all'].search([('active','=',True),('is_inverse','=',False),('this_partner_id','=',record.enterprise_id.id),('type_id','=',int(cla_imputed))],limit=1)
-            cla_start_date = relation.date_start
-            cla_end_date = relation.date_end
-            if isinstance(cla_start_date,date) and cla_start_date > record.date_from:
-                record.date_from = cla_start_date
-            else:
-                record.date_from = record.date_from
-            if isinstance(cla_end_date,date) and record.date_to < cla_end_date:
-                record.date_to = cla_end_date
-        
     def button_declaration_bill_backend(self):
         return {
             'name': 'Rechnungen', 

--- a/syndicom_vollzug/models/vollzug_declaration_check.py
+++ b/syndicom_vollzug/models/vollzug_declaration_check.py
@@ -29,9 +29,6 @@ class SyndicomVollzugDeclarationCheck(models.Model):
 
     def _query(self, with_clause="", fields={}, groupby="", from_clause=""):
 
-        cla_imputed = self.env['ir.config_parameter'].sudo().get_param('syndicom_vollzug.cla_imputed')
-        cla_imputed = str(cla_imputed) if cla_imputed else '0'
-
         return """
 
             SELECT 
@@ -105,7 +102,8 @@ class SyndicomVollzugDeclarationCheck(models.Model):
                             
             FROM 
                         res_partner p
-                        inner join 	res_partner_relation_all con on con.type_id = """ + cla_imputed + """ and con.is_inverse = False and con.this_partner_id = p.id
+                        inner join 	res_partner_relation_all con on con.is_inverse = False and con.this_partner_id = p.id
+                        inner join  res_partner_relation_type rel_type on rel_type.id = con.type_id and rel_type.cla_imputed_ok = True
                         inner join 	res_partner c on c.id = con.other_partner_id
                         
            

--- a/syndicom_vollzug/models/vollzug_declaration_wizard_reminder.py
+++ b/syndicom_vollzug/models/vollzug_declaration_wizard_reminder.py
@@ -94,8 +94,6 @@ class DeclarationEnterpriseToRemind(models.Model):
 
     def _query(self, with_clause="", fields={}, groupby="", from_clause=""):
 
-        cla_imputed = self.env['ir.config_parameter'].sudo().get_param('syndicom_vollzug.cla_imputed')
-        cla_imputed = str(cla_imputed) if cla_imputed else '0'
         stage_id = self.env['syndicom.vollzug.declaration.stage'].search([('process_step','=',1)],limit=1)
         stage_id_waiting = str(stage_id.id) if stage_id else '0'
 
@@ -137,7 +135,8 @@ class DeclarationEnterpriseToRemind(models.Model):
             FROM 
                         res_partner p
                         inner join  syndicom_vollzug_declaration d on d.enterprise_id = p.id and d.date_deadline < current_date  and d.stage_id = """ + stage_id_waiting + """
-                        inner join 	res_partner_relation_all con on con.type_id = """ + cla_imputed + """ and con.is_inverse = False and con.this_partner_id = p.id
+                        inner join 	res_partner_relation_all con on con.is_inverse = False and con.this_partner_id = p.id
+                        inner join  res_partner_relation_type rel_type on rel_type.id = con.type_id and rel_type.cla_imputed_ok = True
                         inner join 	res_partner c on c.id = con.other_partner_id
            
             WHERE

--- a/syndicom_vollzug/views/inherited_res_config_settings.xml
+++ b/syndicom_vollzug/views/inherited_res_config_settings.xml
@@ -21,11 +21,7 @@
                                 <div class="content-group">
 
                                     <div class="row mt16">
-                                    
-                      
-                                        <label class="col-lg-3 o_light_label" string="Unterstellungsverbindung" for="syn_declaration_cla_imputed"/>
-                                        <field name="syn_declaration_cla_imputed" class="oe_inline" style="width: 70% !important;"/>
-                                    
+
                                         <label class="col-lg-3 o_light_label" string="Verbandsverbindung" for="syn_declaration_association_imputed"/>
                                         <field name="syn_declaration_association_imputed" class="oe_inline" style="width: 70% !important;"/>
 

--- a/syndicom_vollzug/views/res_partner_relation_type.xml
+++ b/syndicom_vollzug/views/res_partner_relation_type.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Copyright (c) 2024 braintec AG (https://braintec.com)
+All Rights Reserved
+Licensed under the AGPL-3.0 (http://www.gnu.org/licenses/agpl.html).
+See LICENSE file for full licensing details.
+-->
+<odoo>
+
+    <record id="form_res_partner_relation_type" model="ir.ui.view">
+        <field name="name">res.partner.relation.type.inherit.syndicom_vollzug</field>
+        <field name="model">res.partner.relation.type</field>
+        <field name="inherit_id" ref="partner_multi_relation.form_res_partner_relation_type"/>
+        <field name="arch" type="xml">
+            <field name="handle_invalid_onchange" position="after">
+                <field name="cla_imputed_ok"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="tree_res_partner_relation_type" model="ir.ui.view">
+        <field name="name">res.partner.relation.type.inherit.syndicom_vollzug</field>
+        <field name="model">res.partner.relation.type</field>
+        <field name="inherit_id" ref="partner_multi_relation.tree_res_partner_relation_type"/>
+        <field name="arch" type="xml">
+            <field name="is_symmetric" position="after">
+                <field name="cla_imputed_ok"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
When filtering records in two wizards according to the relation used, a system's parameter was used to define the relation to use in the filtering condition.

The problems were two: 1) Using a system's parameter is a bad idea, and 2) There was the need to filter by more than one relation type, thus the SQL queries had to be changed anyway.

To deal with the need of filtering by more than one relation type, and to get rid of the system's parameter, a new flag has been added to the relation type, named 'Use for CLA Imputed?'. Views have been updated accordingly.

Also, dead-code has been removed, that was found while searching for the old system's parameter variable. Since the method was not used anywhere, it was deleted.

The licence for the module has been set as AGPL-3 given that it depends on the module for partner_multi_relation, licenced as AGPL-3.