### PR TITLE
[t154403][FIX] Use ids in instead of id

### DIFF
--- a/syndicom_vollzug/models/vollzug_declaration_person.py
+++ b/syndicom_vollzug/models/vollzug_declaration_person.py
@@ -236,7 +236,7 @@ class SyndicomvollzugDeclarationPerson(models.Model):
              "&",
              ("date_end", "=", False),
              ("date_end", ">=", dt),
-        ]).id
+        ]).ids
 
     def _get_is_association_this_month(self, association_imputed, dt):
         self.ensure_one()


### PR DESCRIPTION
This way we cover scenarios when the active relations are more than a single record. Otherwise an exception is raised because `.id` can just be used on recordsets of none or one record.