### PR TITLE
[t154382][IMP] Extend declaration rechnungsdaten tab data

### DIFF
--- a/syndicom_vollzug/models/vollzug_declaration.py
+++ b/syndicom_vollzug/models/vollzug_declaration.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
-from odoo import models, fields, api
-from datetime import datetime, timedelta, date
+
+from collections import defaultdict
+from datetime import date
+
+from dateutil.relativedelta import relativedelta
+
+from odoo import api, fields, models
 
 
 class SyndicomvollzugDeclaration(models.Model):
@@ -8,12 +13,12 @@ class SyndicomvollzugDeclaration(models.Model):
     _description = 'Vollzug Deklarationen'
     _inherit = ['mail.thread','mail.activity.mixin']
     name = fields.Char('Name',compute='_compute_name_field')
-    active = fields.Boolean(string='Aktiv',default=True)  
+    active = fields.Boolean(string='Aktiv',default=True)
     currency_id = fields.Many2one('res.currency', 'Währung')
     stage_id = fields.Many2one('syndicom.vollzug.declaration.stage',string='Stufe',group_expand='_read_group_stage_ids')
     enterprise_id = fields.Many2one('res.partner', 'Betrieb', index=True)
     partner_id = fields.Many2one('res.partner', 'Kontakt')
-    responsible_id = fields.Many2one('res.users','Verantwortlich') 
+    responsible_id = fields.Many2one('res.users','Verantwortlich')
     email = fields.Text(string="E-Mail")
     email_cc = fields.Text(string="CCs")
     description = fields.Text(string='Beschreibung')
@@ -24,8 +29,21 @@ class SyndicomvollzugDeclaration(models.Model):
     date_deadline = fields.Date(string='Frist')
     count_mailings = fields.Integer(string='Anzahl Aufforderungen')
     total_ag = fields.Monetary(string='AG Beiträge', compute='_compute_billing_totals')
+    total_ag_nicht_verband = fields.Monetary(
+        'AG Beiträge Nicht-Verband (fakturier)',
+        compute='_compute_billing_totals',
+    )
+    total_ag_verband = fields.Monetary(
+        'AG Beiträge Verband (fakturiert)',
+        compute='_compute_billing_totals',
+    )
+    total_ag_verband_erlassen = fields.Monetary(
+        'AG Beiträge Verband (erlassen)',
+        compute='_compute_billing_totals',
+    )
     total_an_tz = fields.Monetary(string='AN Beiträge TZ', compute='_compute_billing_totals')
     total_an_vz = fields.Monetary(string='AN Beiträge VZ', compute='_compute_billing_totals')
+    total_an_lernende = fields.Monetary('AN Beiträge Lernende', compute='_compute_billing_totals')
     total_an = fields.Monetary(string="AN Beiträge total", compute='_compute_billing_totals')
     total_total = fields.Monetary(string="AN + AG Beiträge total", compute='_compute_billing_totals')
     total_discount = fields.Monetary(string='Rabatt', compute='_compute_billing_totals')
@@ -39,7 +57,7 @@ class SyndicomvollzugDeclaration(models.Model):
     overdue = fields.Boolean(string='Fällig', compute='_compute_overdue')
     total_m = fields.Integer(string='Anz M.',readonly=True,compute='_compute_ma')
     total_w = fields.Integer(string='Anz W.',readonly=True,compute='_compute_ma')
-    total_n = fields.Integer(string='Anz N.',readonly=True,compute='_compute_ma')    
+    total_n = fields.Integer(string='Anz N.',readonly=True,compute='_compute_ma')
     total_a = fields.Integer(string='Anz Lehrlinge',readonly=True,compute='_compute_ma')
     total_ma = fields.Integer(string='Anzahl Mitarbeiter',readonly=True, compute='_compute_ma')
     total_records = fields.Integer(string='Anz. Zeilen',readonly=True, compute='_compute_ma')
@@ -48,7 +66,7 @@ class SyndicomvollzugDeclaration(models.Model):
     duration_vz = fields.Integer(string='Anz. VZ',readonly=True,compute='_compute_duration')
     duration = fields.Integer(string='Anz. Monate',readonly=True,compute='_compute_duration')
     duration_declaration = fields.Integer(string='Anz. Deklarationsmonate',readonly=True,compute='_compute_declaration_months')
-    
+
 
     @api.model
     def _compute_declaration_months(self):
@@ -92,19 +110,19 @@ class SyndicomvollzugDeclaration(models.Model):
 # Wenn es ein Datum Bis hat, dann darf es nicht vor dem record.date_from sein
             for p in person:
                 is_valid = True
-                
+
                 #gueltig berechnen
                 if p.date_entry != False:
                     if p.date_entry >= record.date_to:
                         is_valid = False
-                        
+
                 if p.date_leave != False:
                     if p.date_leave <= record.date_from:
                         is_valid = False
-                        
+
                 if p.date_leave == False and p.date_entry == False:
                     is_valid = False
-                    
+
                 #if (p.date_entry and (not p.date_entry > record.date_to)) and (p.date_leave and (not p.date_leave < record.date_from)):
                 if is_valid == True:
                     if p.ssn not in ahv:
@@ -126,23 +144,35 @@ class SyndicomvollzugDeclaration(models.Model):
 
     def _compute_billing_totals(self):
         """Compute billing data totals for company and employees."""
+        SyndicomVollzugPricelist = self.env['syndicom.vollzug.pricelist']
         # Getting settings records
-        association_imputed_id = int(
-            self.env['ir.config_parameter'].sudo().get_param('syndicom_vollzug.association_imputed'),
-        )
+        association_imputed_id = int(self.env['ir.config_parameter'].sudo().get_param('syndicom_vollzug.association_imputed'))
         ev_imputed_id = int(self.env['ir.config_parameter'].sudo().get_param('syndicom_vollzug.ev_imputed'))
         for declaration in self:
             # Compute the AG totals
             persons = self.env['syndicom.vollzug.declaration.person'].search(
-                [
-                    ('declaration_id', '=', declaration.id),
-                ],
+                [('declaration_id', '=', declaration.id)],
             )
             declaration.total_ag = sum(persons.mapped('total_ag'))
-            total_discount = sum(persons.mapped('discount_ag'))
-
-            # Check the relation table to see if the enterprise is in a association, a ev or none of them
-            is_association_this_month = self.env['res.partner.relation.all'].search(
+            declaration.total_ag_nicht_verband = sum(persons.mapped('total_ag_nicht_verband'))
+            declaration.total_ag_verband = sum(persons.mapped('total_ag_verband'))
+            pricelists = SyndicomVollzugPricelist.search(
+                [
+                    "&", "&", "&",
+                    ("gav_id", "=", declaration.cla_partner.id),
+                    ("date_from", "<=", declaration.date_to),
+                    "|",
+                    ("date_to", "=", False),
+                    ("date_to", ">=", declaration.date_to),
+                    "|",
+                    ("active", "=", True), ("active", "=", False),
+                ],
+            )
+            pricelists_per_cat = defaultdict(self.env['syndicom.vollzug.pricelist'].browse)
+            for pricelist in pricelists:
+                pricelists_per_cat[pricelist.category] += pricelist
+            # Check the relation table to see if the enterprise is in an association, an ev or none of them
+            year_memberships = self.env['res.partner.relation.all'].search(
                 [
                     "&", "&", "&",
                     ("is_inverse", "=", False),
@@ -155,40 +185,40 @@ class SyndicomvollzugDeclaration(models.Model):
                     ("date_end", ">=", declaration.date_from),
                 ],
             )
-            logic = 'nicht'
-            for mon in is_association_this_month:
-                if mon.other_partner_id.id == ev_imputed_id and logic != 'verband':
-                    logic = 'ev'
-                else:
-                    logic = 'verband'
-
-            discount_max = self.env['syndicom.vollzug.pricelist'].search(
-                [
-                    "&", "&", "&", "&",
-                    ("gav_id", "=", declaration.cla_partner.id),
-                    ("date_from", "<=", declaration.date_to),
-                    ("category", "=", logic),
-                    "|",
-                    ("date_to", "=", False),
-                    ("date_to", ">=", declaration.date_to),
-                    "|",
-                    ("active", "=", True), ("active", "=", False),
-                ],
-                limit=1,
-            )
-
-            max_discount = declaration.duration_declaration * discount_max.discount_max
-
-            if total_discount <= max_discount:
-                declaration.total_discount = total_discount
-            else:
-                declaration.total_discount = max_discount
+            max_discount = 0.0
+            if declaration.date_from:
+                end_year = declaration.date_from.replace(month=12, day=31)
+                cursor_date = declaration.date_from.replace(day=1)
+                # Iterate the months of the year that apply
+                while cursor_date <= end_year:
+                    memberships = year_memberships._get_by_date(cursor_date)
+                    if memberships and all(m.other_partner_id.id == ev_imputed_id for m in memberships):
+                        max_discount += pricelists_per_cat.get('ev', SyndicomVollzugPricelist)._get_by_date(cursor_date).discount_max
+                    elif memberships:
+                        max_discount += pricelists_per_cat.get('verband', SyndicomVollzugPricelist)._get_by_date(cursor_date).discount_max
+                    else:
+                        # Just take the max_discount from the pricelist of type 'nicht'
+                        max_discount += pricelists_per_cat.get('nicht', SyndicomVollzugPricelist)._get_by_date(cursor_date).discount_max
+                    cursor_date = cursor_date + relativedelta(months=1)
+            # If max_discount is zero, then we will take the total_ag as plafoniert because it doesn't apply
+            declaration.total_discount = min(declaration.total_ag, int(max_discount)) or declaration.total_ag
+            declaration.total_ag_verband_erlassen = -(declaration.total_discount - declaration.total_ag_nicht_verband)
             # Compute the AN totals
-            declaration.total_an_tz = sum(persons.mapped(lambda p: p.total_an if p.employment_rate < 50 else 0))
-            declaration.total_an_vz = sum(persons.mapped(lambda p: p.total_an if p.employment_rate >= 50 else 0))
-            declaration.total_an = declaration.total_an_tz + declaration.total_an_vz
+            total_an_lernende, total_an_tz, total_an_vz = 0, 0, 0
+            for person in persons:
+                if person.is_apprentice:
+                    total_an_lernende += person.total_an
+                elif person.employment_rate < 50:
+                    total_an_tz += person.total_an
+                else:
+                    total_an_vz += person.total_an
+            # Assign AN totals
+            declaration.total_an_tz = total_an_tz
+            declaration.total_an_vz = total_an_vz
+            declaration.total_an_lernende = total_an_lernende
+            declaration.total_an = declaration.total_an_tz + declaration.total_an_vz + declaration.total_an_lernende
             # And finally the summed up total amount
-            declaration.total_total = declaration.total_discount + declaration.total_an
+            declaration.total_total = declaration.total_discount + declaration.total_an + declaration.total_ag_verband_erlassen
 
     def _read_group_stage_ids(self, stage_id, domain, order):
         stage_ids = self.env['syndicom.vollzug.declaration.stage'].search([])
@@ -203,7 +233,7 @@ class SyndicomvollzugDeclaration(models.Model):
 
     def button_declaration_bill_backend(self):
         return {
-            'name': 'Rechnungen', 
+            'name': 'Rechnungen',
             'view_mode': 'tree,form',
             'res_model': 'account.move',
             'type': 'ir.actions.act_window',
@@ -215,11 +245,11 @@ class SyndicomvollzugDeclaration(models.Model):
             'name': 'Deklarierte Personen',
             'view_mode': 'tree',
             #'view_id' : 'deklarierte_personen_tree_view',
-            'res_model': 'syndicom.vollzug.declaration.person', 
-            'type': 'ir.actions.act_window', 
-            'domain': [('declaration_id','=',self.id)] 
+            'res_model': 'syndicom.vollzug.declaration.person',
+            'type': 'ir.actions.act_window',
+            'domain': [('declaration_id','=',self.id)]
             }
-         
+
     def _compute_person_count(self):
         for res in self:
             res.person_count = len(self.env['syndicom.vollzug.declaration.person'].search([('declaration_id', '=', res.id)]))

--- a/syndicom_vollzug/models/vollzug_declaration_person.py
+++ b/syndicom_vollzug/models/vollzug_declaration_person.py
@@ -33,6 +33,8 @@ class SyndicomvollzugDeclarationPerson(models.Model):
 
     total_an = fields.Monetary(string='AN Beitrag') #,compute="_compute_total_an")
     total_ag = fields.Monetary(string='AG Beitrag') #,compute="_compute_total_ag")
+    total_ag_nicht_verband = fields.Monetary(compute='_compute_duration_in_month')
+    total_ag_verband = fields.Monetary(compute='_compute_duration_in_month')
     salutation = fields.Char(string='Anrede')
     street = fields.Char(string='Adresse')
     zip = fields.Char(string='PLZ')
@@ -91,6 +93,8 @@ class SyndicomvollzugDeclarationPerson(models.Model):
                 duration_ev = 0
                 duration_none = 0
                 total_ag = 0
+                total_ag_verband = 0
+                total_ag_nicht_verband = 0
                 total_an = 0
                 discount_ag = 0
 
@@ -196,11 +200,17 @@ class SyndicomvollzugDeclarationPerson(models.Model):
                                     total_ag_this_month = (record.salary / 100 * pricelist.amount_ag_vz)
                                     total_an = total_an + (record.salary / 100 * pricelist.amount_vz)
                             discount_ag = discount_ag + (total_ag_this_month / 100 * pricelist.discount)
+                            if pricelist.category == 'verband':
+                                total_ag_verband += total_ag_this_month
+                            else:
+                                total_ag_nicht_verband += total_ag_this_month
 
                 if record.duration_correction != 0 and m > 0:
                     if (m == record.duration_association) or (m == duration_ev) or (m == duration_none):
                         total_an = total_an / m * (m + record.duration_correction)
                         total_ag = total_ag / m * (m + record.duration_correction)
+                        total_ag_nicht_verband = total_ag_nicht_verband / m * (m + record.duration_correction)
+                        total_ag_verband = total_ag_verband / m * (m + record.duration_correction)
                         discount_ag = discount_ag / m * (m + record.duration_correction)
 
                 record.duration_association = max(0, duration_asso)
@@ -209,6 +219,8 @@ class SyndicomvollzugDeclarationPerson(models.Model):
                 record.duration = max(0,record.duration_association + record.duration_ev + record.duration_none)
                 record.total_an = max(0,total_an)
                 record.total_ag = max(0,total_ag)
+                record.total_ag_nicht_verband = max(0,total_ag_nicht_verband)
+                record.total_ag_verband = max(0,total_ag_verband)
                 record.discount_ag = max(0,discount_ag)
 
             else:
@@ -218,6 +230,8 @@ class SyndicomvollzugDeclarationPerson(models.Model):
                 record.duration = 0
                 record.total_an = 0
                 record.total_ag = 0
+                record.total_ag_nicht_verband = 0
+                record.total_ag_verband = 0
                 record.discount_ag = 0
 
     @api.model

--- a/syndicom_vollzug/models/vollzug_pricelist.py
+++ b/syndicom_vollzug/models/vollzug_pricelist.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-from odoo import models, fields, api
-from datetime import datetime, timedelta, date
+from odoo import models, fields
+from datetime import date
+
 
 class SyndicomVollzugPricelist(models.Model):
     _name = 'syndicom.vollzug.pricelist'
@@ -41,10 +42,9 @@ class SyndicomVollzugPricelist(models.Model):
             else:
                 rec.active = False
 
-
-    
-
-
-    
-    
-    
+    def _get_by_date(self, filter_date):
+        """Return the first valid pricelist for a given date from a recordset."""
+        for pricelist in self:
+            if (pricelist.date_from or filter_date).replace(day=1) <= filter_date <= (pricelist.date_to or filter_date):
+                return pricelist
+        return self.env['syndicom.vollzug.pricelist']

--- a/syndicom_vollzug/views/vollzug_declaration.xml
+++ b/syndicom_vollzug/views/vollzug_declaration.xml
@@ -58,7 +58,7 @@
             <field name="kanban_state"/>
             <progressbar field="kanban_state" colors='{"done": "success", "blocked": "danger", "normal": "muted"}'/>
                 <templates>
-          
+
 
 
                 <t t-name="kanban-box">
@@ -90,7 +90,9 @@
                                         <field name="date_deadline" widget="remaining_days"/>
                                     </div>
                                 </div>
-                                
+                                <div class="oe_kanban_bottom_right text-info" style="font-size: 0.7em;">
+                                    <field name="cla_partner"/>
+                                </div>
                             </div>
                         </div>
                         <div class="oe_clear"/>
@@ -192,25 +194,21 @@
                            
                         </page>
                         <page string="Rechnungsdaten" name="page_vollzug_declaration_bill">
-
                             <group>
                                 <group name="content_left">
-
                                     <field name="total_ag" string="AG-Beiträge (nicht plafoniert)" />
                                     <field name="total_discount" string="AG-Beiträge (plafoniert)" />
-
+                                    <field name="total_ag_nicht_verband"/>
+                                    <field name="total_ag_verband"/>
+                                    <field name="total_ag_verband_erlassen"/>
                                     <field name="total_an_tz" />
                                     <field name="total_an_vz" />
+                                    <field name="total_an_lernende"/>
                                     <field name="total_an" />
-
                                     <field name="total_total" />
-                                    
-                                   
                                 </group>
                                 <group name="content_right">
-                                   
-                                    <field name="move_id" type="object" attrs="{'invisible':[('move_id','=',False)]}" />
-
+                                    <field name="move_id" type="object" attrs="{'invisible':[('move_id','=',False)]}"/>
                                 </group>
                             </group>
 


### PR DESCRIPTION
I have added all the new requested fields and adapted/extended the existing logic.

Also all the total Rechnungsdate tab fields which are computed are now using the same computed method, this is to avoid dependencies between them (computed field depending on computed field happening in an-expected order), and also for performance reasons, in general in Odoo we should group computed fields under the same computed method always that is possible.