### PR TITLE
[t156241][FIX] Remove unused fields

### DIFF
--- a/syndicom_vollzug/models/res_config_settings.py
+++ b/syndicom_vollzug/models/res_config_settings.py
@@ -15,17 +15,9 @@ class ResConfigSettings(models.TransientModel):
         default="", 
         )
 
-    syn_partner_cc = fields.Many2one(comodel_name='res.partner',string='Partner CC Berechnung',
-        config_parameter='syndicom_vollzug.cla_logic_cc',
-        default=55247)
-
     syn_company_cc = fields.Many2one(comodel_name='res.company',string='Company CC',
         config_parameter='syndicom_vollzug.syn_company_cc',
         default=0)
-
-    syn_partner_nz = fields.Many2one(comodel_name='res.partner',string='Partner NZ Berechnung',
-        config_parameter='syndicom_vollzug.cla_logic_nz',
-        default=55250)
 
     syn_company_nz = fields.Many2one(comodel_name='res.company',string='Company nz',
         config_parameter='syndicom_vollzug.syn_company_nz',

--- a/syndicom_vollzug/views/inherited_res_config_settings.xml
+++ b/syndicom_vollzug/views/inherited_res_config_settings.xml
@@ -35,8 +35,6 @@
                                             Contact / Callcenter
                                         </div>
                                     <div class="row mt16">
-                                        <label class="col-lg-3 o_light_label" string="Partner GAV CC" for="syn_partner_cc"/>
-                                        <field name="syn_partner_cc" class="oe_inline" style="width: 70% !important;"/>
                                         <label class="col-lg-3 o_light_label" string="Company CC" for="syn_company_cc"/>
                                         <field name="syn_company_cc" class="oe_inline" style="width: 70% !important;"/>
                                         <label class="col-lg-3 o_light_label" string="Produkt Deklaration Teilzeit" for="syn_prod_cc_tz"/>
@@ -71,8 +69,6 @@
                                            Netzinfrastruktur
                                         </div>
                                     <div class="row mt16">
-                                        <label class="col-lg-3 o_light_label" string="Partner GAV NZ" for="syn_partner_nz"/>
-                                        <field name="syn_partner_nz" class="oe_inline" style="width: 70% !important;"/>
                                         <label class="col-lg-3 o_light_label" string="Company NZ" for="syn_company_nz"/>
                                         <field name="syn_company_nz" class="oe_inline" style="width: 70% !important;"/>
                                         <label class="col-lg-3 o_light_label" string="Produkt Deklaration Teilzeit" for="syn_prod_nz_tz"/>


### PR DESCRIPTION
The fields defined as a default value a non-existing ID for a res.partner. This made the automated tests to crash. This hardcoding of IDs is a bad practice that we could solve by simply removing the definition of the fields, since they are not being used anywhere (other than in the views).
