### PR TITLE
[FIX] Include archived relations when retrieving memberships

### DIFF
--- a/syndicom_vollzug/models/vollzug_declaration.py
+++ b/syndicom_vollzug/models/vollzug_declaration.py
@@ -178,7 +178,7 @@ class SyndicomvollzugDeclaration(models.Model):
             # Check the relation table to see if the enterprise is in an association, an ev or none of them
             year_memberships = self.env['res.partner.relation.all'].search(
                 [
-                    "&", "&", "&",
+                    "&", "&", "&", "&",
                     ("is_inverse", "=", False),
                     ("this_partner_id", "=", declaration.enterprise_id.id),
                     ("type_id", "=", association_imputed_id),
@@ -187,6 +187,8 @@ class SyndicomvollzugDeclaration(models.Model):
                     "&",
                     ("date_end", "=", False),
                     ("date_end", ">=", declaration.date_from),
+                    "|",
+                    ("active", "=", True), ("active", "=", False),
                 ],
             )
             if declaration.date_from:


### PR DESCRIPTION
Some of the relations were automatically archived by Odoo, since the date range were not covering the whole current year. When records are archived, Odoo by default won't return them when querying the database, if we don't request this expressly.

In reality, we should focus on the filtering we have already in place, where we look at the date_start and date_end. If the relation is archived at the present day but applied in its date range we have to use it.