### PR TITLE
874891 Add computed fields for Swisscom and Post retirees, and manual company flags for Syndicom Newsletter

### DIFF
--- a/syndicom_newsletter/__init__.py
+++ b/syndicom_newsletter/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/syndicom_newsletter/__manifest__.py
+++ b/syndicom_newsletter/__manifest__.py
@@ -1,7 +1,7 @@
 {
-    "name": "Partner Purer Swisscom Rentner",
+    "name": "Partner Purer Swisscom / Post Rentner",
     "version": "1.0",
-    "summary": "Compute Swisscom Rentner status on Partners",
+    "summary": "Compute Swisscom/Post Rentner status on Partners",
     "author": "ChatGPT",
     "category": "Contacts",
     "depends": ["base"],

--- a/syndicom_newsletter/__manifest__.py
+++ b/syndicom_newsletter/__manifest__.py
@@ -1,0 +1,12 @@
+{
+    "name": "Partner Purer Swisscom Rentner",
+    "version": "1.0",
+    "summary": "Compute Swisscom Rentner status on Partners",
+    "author": "ChatGPT",
+    "category": "Contacts",
+    "depends": ["base"],
+    "data": [],
+    "installable": true,
+    "application": false,
+    "auto_install": false
+}

--- a/syndicom_newsletter/models/__init__.py
+++ b/syndicom_newsletter/models/__init__.py
@@ -1,0 +1,1 @@
+from . import res_partner

--- a/syndicom_newsletter/models/res_partner.py
+++ b/syndicom_newsletter/models/res_partner.py
@@ -1,0 +1,62 @@
+from odoo import models, fields, api
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    x_studio_purer_swisscom_rentner = fields.Boolean(
+        string='Purer Swisscom Rentner',
+        compute='_compute_purer_swisscom_rentner',
+        store=True
+    )
+
+    @api.depends(
+        'member_retired',
+        'is_syndicom_member',
+        'work_partner_relation_ids.other_partner_id.name',
+        'work_partner_relation_ids.date_start',
+        'work_partner_relation_ids.date_end'
+    )
+    def _compute_purer_swisscom_rentner(self):
+        for partner in self:
+            partner.x_studio_purer_swisscom_rentner = False
+
+            if not (partner.member_retired and partner.is_syndicom_member):
+                continue
+
+            relations = partner.work_partner_relation_ids
+
+            swisscom_or_cablex = relations.filtered(
+                lambda r: r.other_partner_id and (
+                    'swisscom' in (r.other_partner_id.name or '').lower() or
+                    'cablex' in (r.other_partner_id.name or '').lower()
+                )
+            )
+            unknown_employers = relations.filtered(
+                lambda r: r.other_partner_id and r.other_partner_id.name == 'kein Arbeitgeber / Arbeitgeber unbekannt'
+            )
+            other_employers = relations.filtered(
+                lambda r: r.other_partner_id and not any(
+                    kw in (r.other_partner_id.name or '').lower()
+                    for kw in ['swisscom', 'cablex', 'kein arbeitgeber / arbeitgeber unbekannt']
+                )
+            )
+
+            if not swisscom_or_cablex:
+                continue
+
+            if other_employers:
+                continue
+
+            valid_unknown = False
+            if unknown_employers:
+                latest_unknown = max(
+                    unknown_employers,
+                    key=lambda r: r.date_start or fields.Date.today()
+                )
+                if not latest_unknown.date_end:
+                    valid_unknown = True
+
+            if not valid_unknown:
+                continue
+
+            partner.x_studio_purer_swisscom_rentner = True

--- a/syndicom_newsletter/models/res_partner.py
+++ b/syndicom_newsletter/models/res_partner.py
@@ -80,8 +80,8 @@ class ResPartner(models.Model):
             if not valid_unknown:
                 continue
 
+            # New check: must have at least one Swisscom/Post employer
             if swisscom_employers:
                 partner.pure_swisscom_rentner = True
-
             if post_employers:
                 partner.pure_post_rentner = True


### PR DESCRIPTION
This Pull Request introduces four fields on the `res.partner` model:

- `pure_swisscom_rentner` (computed boolean)
- `pure_post_rentner` (computed boolean)
- `is_swisscom_company` (manual boolean)
- `is_post_company` (manual boolean)

The computed fields identify retired Syndicom members who previously worked at Swisscom, Cablex, or Post, have no other employer listed, and whose last known employer is either one of these or "kein Arbeitgeber / Arbeitgeber unbekannt" without a contract end date.

Instead of relying on partner name or category matching, the logic now uses two manually controlled flags `is_swisscom_company` and `is_post_company` on the employer partner records, providing a cleaner and more reliable mechanism.

Key logic:
- `member_retired = True`
- `is_syndicom_member = True`
- Past employment must match a partner manually marked as Swisscom or Post company
- No other employers allowed
- "Kein Arbeitgeber / Arbeitgeber unbekannt" must have either the latest start date or no end date

This ensures only valid Swisscom or Post retirees are included in the newsletter campaigns.

All fields are stored and updated automatically when relevant fields change.


[Related Helpdesk Ticket](https://odoo.syndicom.ch/web#id=874891&menu_id=524&cids=1&action=760&active_id=2&model=helpdesk.ticket&view_type=form)